### PR TITLE
Remove password check from users in fb

### DIFF
--- a/rules.json
+++ b/rules.json
@@ -7,13 +7,10 @@
     // Make sure that users have an email field and that an email is a string that matches this regex provided by Firebase
     "users": {
       "$users": {
-        ".validate": "newData.hasChildren(['email', 'password'])",
+        ".validate": "newData.hasChildren(['email'])",
         "email": {
           ".validate": "newData.isString() &&
                         newData.val().matches(/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,4}$/i)"
-        },
-        "password": {
-          ".validate": "true"
         },
         "$other": {
           ".validate": "false"


### PR DESCRIPTION
This just removes checks for the password field under users -- Firebase stores user's passwords for us with their auth methods so we probably don't actually want them in our data.

@nickcharles @matthewgrossman 
